### PR TITLE
Feature: adding oauth2 client login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <os-maven-plugin.version>1.6.1</os-maven-plugin.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <javax-annotation.version>1.2</javax-annotation.version>
+        <nimbus-jose-jwt.version>9.30.1</nimbus-jose-jwt.version>
     </properties>
 
     <dependencies>
@@ -77,6 +78,17 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>${javax-annotation.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>${nimbus-jose-jwt.version}</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/ea/restaurant/constants/Oauth2.java
+++ b/src/main/java/com/ea/restaurant/constants/Oauth2.java
@@ -1,0 +1,13 @@
+package com.ea.restaurant.constants;
+
+public class Oauth2 {
+
+  public enum GranType {
+    CLIENT_CREDENTIALS
+  }
+
+  public enum TokenType {
+    ACCESS_TOKEN,
+    REFRESH_TOKEN
+  }
+}

--- a/src/main/java/com/ea/restaurant/dtos/LoginResponseDto.java
+++ b/src/main/java/com/ea/restaurant/dtos/LoginResponseDto.java
@@ -1,0 +1,18 @@
+package com.ea.restaurant.dtos;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@EqualsAndHashCode
+@Setter
+@Getter
+@Builder
+public class LoginResponseDto {
+  private String accessToken;
+  private String refreshToken;
+  private Integer expiresIn;
+  private String scopes;
+  private String clientName;
+}

--- a/src/main/java/com/ea/restaurant/entities/AppClientScope.java
+++ b/src/main/java/com/ea/restaurant/entities/AppClientScope.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 @Table(name = "app_clients_scopes")
 public class AppClientScope extends BaseEntity {
   @NotNull private Long appClientId;
-  @NotNull private String scope;
+  @NotNull private String scopes;
 
   public AppClientScope(Long id) {
     super(id);

--- a/src/main/java/com/ea/restaurant/entities/AppRefreshToken.java
+++ b/src/main/java/com/ea/restaurant/entities/AppRefreshToken.java
@@ -1,7 +1,10 @@
 package com.ea.restaurant.entities;
 
+import com.ea.restaurant.constants.Oauth2;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,7 +28,11 @@ public class AppRefreshToken {
   private Long id;
 
   @NotNull private String token;
-  private String grantType;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private Oauth2.GranType grantType;
+
   private Long appClientId;
 
   public AppRefreshToken(Long id) {

--- a/src/main/java/com/ea/restaurant/exceptions/BcryptException.java
+++ b/src/main/java/com/ea/restaurant/exceptions/BcryptException.java
@@ -1,0 +1,7 @@
+package com.ea.restaurant.exceptions;
+
+public class BcryptException extends RuntimeException {
+  public BcryptException() {
+    super("Invalid credentials");
+  }
+}

--- a/src/main/java/com/ea/restaurant/exceptions/WrongCredentialsException.java
+++ b/src/main/java/com/ea/restaurant/exceptions/WrongCredentialsException.java
@@ -1,0 +1,7 @@
+package com.ea.restaurant.exceptions;
+
+public class WrongCredentialsException extends RuntimeException {
+  public WrongCredentialsException() {
+    super("Wrong Credentials");
+  }
+}

--- a/src/main/java/com/ea/restaurant/repository/AppAccessTokenRepository.java
+++ b/src/main/java/com/ea/restaurant/repository/AppAccessTokenRepository.java
@@ -1,0 +1,8 @@
+package com.ea.restaurant.repository;
+
+import com.ea.restaurant.entities.AppAccessToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AppAccessTokenRepository extends JpaRepository<AppAccessToken, Long> {}

--- a/src/main/java/com/ea/restaurant/repository/AppClientRepository.java
+++ b/src/main/java/com/ea/restaurant/repository/AppClientRepository.java
@@ -1,0 +1,14 @@
+package com.ea.restaurant.repository;
+
+import com.ea.restaurant.constants.Status;
+import com.ea.restaurant.entities.AppClient;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AppClientRepository extends JpaRepository<AppClient, Long> {
+  Optional<AppClient> findByIdAndEntityStatus(Long id, Status status);
+
+  Optional<AppClient> findByClientIdAndEntityStatus(String clientId, Status status);
+}

--- a/src/main/java/com/ea/restaurant/repository/AppClientScopeRepository.java
+++ b/src/main/java/com/ea/restaurant/repository/AppClientScopeRepository.java
@@ -1,0 +1,12 @@
+package com.ea.restaurant.repository;
+
+import com.ea.restaurant.constants.Status;
+import com.ea.restaurant.entities.AppClientScope;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AppClientScopeRepository extends JpaRepository<AppClientScope, Long> {
+  Optional<AppClientScope> findByAppClientIdAndEntityStatus(Long appClientId, Status status);
+}

--- a/src/main/java/com/ea/restaurant/repository/AppRefreshTokenRepository.java
+++ b/src/main/java/com/ea/restaurant/repository/AppRefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.ea.restaurant.repository;
+
+import com.ea.restaurant.entities.AppRefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AppRefreshTokenRepository extends JpaRepository<AppRefreshToken, Long> {}

--- a/src/main/java/com/ea/restaurant/service/Oauth2Service.java
+++ b/src/main/java/com/ea/restaurant/service/Oauth2Service.java
@@ -1,0 +1,11 @@
+package com.ea.restaurant.service;
+
+import com.ea.restaurant.dtos.LoginResponseDto;
+import com.nimbusds.jose.JOSEException;
+import java.io.UnsupportedEncodingException;
+
+public interface Oauth2Service {
+
+  LoginResponseDto loginClient(String clientId, String clientSecret)
+      throws UnsupportedEncodingException, JOSEException;
+}

--- a/src/main/java/com/ea/restaurant/service/impl/Oauth2ServiceImpl.java
+++ b/src/main/java/com/ea/restaurant/service/impl/Oauth2ServiceImpl.java
@@ -1,0 +1,101 @@
+package com.ea.restaurant.service.impl;
+
+import com.ea.restaurant.constants.Oauth2;
+import com.ea.restaurant.constants.Oauth2.GranType;
+import com.ea.restaurant.constants.Status;
+import com.ea.restaurant.dtos.LoginResponseDto;
+import com.ea.restaurant.entities.AppAccessToken;
+import com.ea.restaurant.entities.AppClient;
+import com.ea.restaurant.entities.AppRefreshToken;
+import com.ea.restaurant.exceptions.BcryptException;
+import com.ea.restaurant.exceptions.EntityNotFoundException;
+import com.ea.restaurant.repository.AppAccessTokenRepository;
+import com.ea.restaurant.repository.AppClientRepository;
+import com.ea.restaurant.repository.AppClientScopeRepository;
+import com.ea.restaurant.repository.AppRefreshTokenRepository;
+import com.ea.restaurant.service.Oauth2Service;
+import com.ea.restaurant.utils.Oauth2Util;
+import com.nimbusds.jose.JOSEException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Service;
+
+@Service
+public class Oauth2ServiceImpl implements Oauth2Service {
+
+  private final String oauth2SecretKey;
+  private final AppClientRepository appClientRepository;
+  private final AppClientScopeRepository appClientScopeRepository;
+  private final AppRefreshTokenRepository appRefreshTokenRepository;
+  private final AppAccessTokenRepository appAccessTokenRepository;
+
+  public Oauth2ServiceImpl(
+      @Value("${oauth2.secret.key}") String oauth2SecretKey,
+      AppClientRepository appClientRepository,
+      AppClientScopeRepository appClientScopeRepository,
+      AppAccessTokenRepository appAccessTokenRepository,
+      AppRefreshTokenRepository appRefreshTokenRepository) {
+    this.oauth2SecretKey = oauth2SecretKey;
+    this.appClientRepository = appClientRepository;
+    this.appClientScopeRepository = appClientScopeRepository;
+    this.appAccessTokenRepository = appAccessTokenRepository;
+    this.appRefreshTokenRepository = appRefreshTokenRepository;
+  }
+
+  @Override
+  public LoginResponseDto loginClient(String clientId, String clientSecret) throws JOSEException {
+    validateClientCredentials(clientId, clientSecret);
+    var client =
+        this.appClientRepository
+            .findByClientIdAndEntityStatus(clientId, Status.ACTIVE)
+            .orElseThrow(EntityNotFoundException::new);
+    var scopes =
+        this.appClientScopeRepository
+            .findByAppClientIdAndEntityStatus(client.getId(), Status.ACTIVE)
+            .orElseThrow(EntityNotFoundException::new);
+    var accessToken =
+        Oauth2Util.buildClientCredentialsToken(
+            client, scopes, oauth2SecretKey, Oauth2.TokenType.ACCESS_TOKEN);
+    var refreshToken =
+        Oauth2Util.buildClientCredentialsToken(
+            client, scopes, oauth2SecretKey, Oauth2.TokenType.REFRESH_TOKEN);
+
+    var persistedRefreshToken = createRefreshToken(refreshToken, client);
+    createAccessToken(accessToken, persistedRefreshToken);
+
+    return LoginResponseDto.builder()
+        .clientName(client.getClientName())
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .scopes(scopes.getScopes())
+        .expiresIn(client.getAccessTokenExpirationTime())
+        .build();
+  }
+
+  private void createAccessToken(String accessToken, AppRefreshToken appRefreshToken) {
+    var appAccessToken = new AppAccessToken();
+    appAccessToken.setRefreshTokenId(appRefreshToken.getId());
+    appAccessToken.setToken(accessToken);
+    this.appAccessTokenRepository.save(appAccessToken);
+  }
+
+  private AppRefreshToken createRefreshToken(String refreshToken, AppClient client) {
+    var appRefreshToken = new AppRefreshToken();
+    appRefreshToken.setToken(refreshToken);
+    appRefreshToken.setAppClientId(client.getId());
+    appRefreshToken.setGrantType(GranType.CLIENT_CREDENTIALS);
+    return this.appRefreshTokenRepository.save(appRefreshToken);
+  }
+
+  private void validateClientCredentials(String clientId, String clientSecret) {
+
+    var client =
+        this.appClientRepository
+            .findByClientIdAndEntityStatus(clientId, Status.ACTIVE)
+            .orElseThrow(EntityNotFoundException::new);
+
+    if (!(BCrypt.checkpw(clientSecret, client.getClientSecret()))) {
+      throw new BcryptException();
+    }
+  }
+}

--- a/src/main/java/com/ea/restaurant/service/impl/Oauth2ServiceImpl.java
+++ b/src/main/java/com/ea/restaurant/service/impl/Oauth2ServiceImpl.java
@@ -9,6 +9,7 @@ import com.ea.restaurant.entities.AppClient;
 import com.ea.restaurant.entities.AppRefreshToken;
 import com.ea.restaurant.exceptions.BcryptException;
 import com.ea.restaurant.exceptions.EntityNotFoundException;
+import com.ea.restaurant.exceptions.WrongCredentialsException;
 import com.ea.restaurant.repository.AppAccessTokenRepository;
 import com.ea.restaurant.repository.AppClientRepository;
 import com.ea.restaurant.repository.AppClientScopeRepository;
@@ -48,7 +49,7 @@ public class Oauth2ServiceImpl implements Oauth2Service {
     var client =
         this.appClientRepository
             .findByClientIdAndEntityStatus(clientId, Status.ACTIVE)
-            .orElseThrow(EntityNotFoundException::new);
+            .orElseThrow(WrongCredentialsException::new);
     var scopes =
         this.appClientScopeRepository
             .findByAppClientIdAndEntityStatus(client.getId(), Status.ACTIVE)
@@ -92,7 +93,7 @@ public class Oauth2ServiceImpl implements Oauth2Service {
     var client =
         this.appClientRepository
             .findByClientIdAndEntityStatus(clientId, Status.ACTIVE)
-            .orElseThrow(EntityNotFoundException::new);
+            .orElseThrow(WrongCredentialsException::new);
 
     if (!(BCrypt.checkpw(clientSecret, client.getClientSecret()))) {
       throw new BcryptException();

--- a/src/main/java/com/ea/restaurant/utils/Oauth2Util.java
+++ b/src/main/java/com/ea/restaurant/utils/Oauth2Util.java
@@ -1,0 +1,47 @@
+package com.ea.restaurant.utils;
+
+import com.ea.restaurant.constants.Oauth2;
+import com.ea.restaurant.entities.AppClient;
+import com.ea.restaurant.entities.AppClientScope;
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.DirectEncrypter;
+import com.nimbusds.jwt.JWTClaimsSet;
+import java.util.Date;
+
+public final class Oauth2Util {
+
+  public static String buildClientCredentialsToken(
+      AppClient client,
+      AppClientScope appClientScope,
+      String oauth2Secret,
+      Oauth2.TokenType tokenType)
+      throws JOSEException {
+    Date now = new Date();
+    var expirationTime =
+        (tokenType == Oauth2.TokenType.ACCESS_TOKEN)
+            ? (client.getAccessTokenExpirationTime())
+            : (client.getRefreshTokenExpirationTime());
+
+    var claims =
+        new JWTClaimsSet.Builder()
+            .claim("clientName", client.getClientName())
+            .claim("scopes", appClientScope.getScopes())
+            .expirationTime(new Date(now.getTime() + expirationTime))
+            .build();
+
+    var payload = new Payload(claims.toJSONObject());
+
+    var header = new JWEHeader(JWEAlgorithm.DIR, EncryptionMethod.A128CBC_HS256);
+
+    var secretKeyEncrypted = oauth2Secret.getBytes();
+    var encrypted = new DirectEncrypter(secretKeyEncrypted);
+    var token = new JWEObject(header, payload);
+    token.encrypt(encrypted);
+    return token.serialize();
+  }
+}

--- a/src/main/java/com/ea/restaurant/utils/Oauth2Util.java
+++ b/src/main/java/com/ea/restaurant/utils/Oauth2Util.java
@@ -10,10 +10,19 @@ import com.nimbusds.jose.JWEHeader;
 import com.nimbusds.jose.JWEObject;
 import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.crypto.DirectEncrypter;
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWEDecryptionKeySelector;
+import com.nimbusds.jose.proc.JWEKeySelector;
+import com.nimbusds.jose.proc.SimpleSecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import java.text.ParseException;
 import java.util.Date;
 
-public final class Oauth2Util {
+public class Oauth2Util {
 
   public static String buildClientCredentialsToken(
       AppClient client,
@@ -43,5 +52,19 @@ public final class Oauth2Util {
     var token = new JWEObject(header, payload);
     token.encrypt(encrypted);
     return token.serialize();
+  }
+
+  public static JWTClaimsSet getTokenDecoded(String token, String secretKey)
+      throws BadJOSEException, ParseException, JOSEException {
+    ConfigurableJWTProcessor<SimpleSecurityContext> jwtProcessor =
+        new DefaultJWTProcessor<SimpleSecurityContext>();
+    JWKSource<SimpleSecurityContext> jweKeySource =
+        new ImmutableSecret<SimpleSecurityContext>(secretKey.getBytes());
+    JWEKeySelector<SimpleSecurityContext> jweKeySelector =
+        new JWEDecryptionKeySelector<SimpleSecurityContext>(
+            JWEAlgorithm.DIR, EncryptionMethod.A128CBC_HS256, jweKeySource);
+    jwtProcessor.setJWEKeySelector(jweKeySelector);
+
+    return jwtProcessor.process(token, null);
   }
 }

--- a/src/main/resources/application-example.properties
+++ b/src/main/resources/application-example.properties
@@ -2,3 +2,5 @@
 spring.datasource.url=
 spring.datasource.username=
 spring.datasource.password=
+
+oauth2.secret.key=

--- a/src/test/java/com/ea/restaurant/service/impl/Oauth2ServiceImplTest.java
+++ b/src/test/java/com/ea/restaurant/service/impl/Oauth2ServiceImplTest.java
@@ -1,0 +1,118 @@
+package com.ea.restaurant.service.impl;
+
+import com.ea.restaurant.constants.Oauth2;
+import com.ea.restaurant.constants.Status;
+import com.ea.restaurant.entities.AppClient;
+import com.ea.restaurant.entities.AppClientScope;
+import com.ea.restaurant.entities.AppRefreshToken;
+import com.ea.restaurant.repository.AppAccessTokenRepository;
+import com.ea.restaurant.repository.AppClientRepository;
+import com.ea.restaurant.repository.AppClientScopeRepository;
+import com.ea.restaurant.repository.AppRefreshTokenRepository;
+import com.ea.restaurant.service.Oauth2Service;
+import com.ea.restaurant.utils.Oauth2Util;
+import com.ea.restaurant.utils.fixtures.AppAccessTokenFixture;
+import com.ea.restaurant.utils.fixtures.AppClientFixture;
+import com.ea.restaurant.utils.fixtures.AppClientScopeFixture;
+import com.ea.restaurant.utils.fixtures.AppRefreshTokenFixture;
+import com.ea.restaurant.utils.fixtures.Oauth2Fixture;
+import com.nimbusds.jose.JOSEException;
+import java.io.UnsupportedEncodingException;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class Oauth2ServiceImplTest {
+  private Oauth2Service oauth2Service;
+  private AppClientRepository appClientRepository;
+  private AppClientScopeRepository appClientScopeRepository;
+  private AppAccessTokenRepository appAccessTokenRepository;
+  private AppRefreshTokenRepository appRefreshTokenRepository;
+  private AppClient appClient;
+  private AppClientScope appClientScope;
+  private AppRefreshToken appRefreshToken;
+
+  @BeforeEach
+  public void setUp() throws JOSEException {
+
+    appClientRepository = Mockito.mock(AppClientRepository.class);
+    appClientScopeRepository = Mockito.mock(AppClientScopeRepository.class);
+    appAccessTokenRepository = Mockito.mock(AppAccessTokenRepository.class);
+    appRefreshTokenRepository = Mockito.mock(AppRefreshTokenRepository.class);
+    oauth2Service =
+        new Oauth2ServiceImpl(
+            Oauth2Fixture.SECRET_KEY,
+            appClientRepository,
+            appClientScopeRepository,
+            appAccessTokenRepository,
+            appRefreshTokenRepository);
+    MockitoAnnotations.openMocks(this);
+    appClient = AppClientFixture.buildAppClient(1L);
+    appClientScope = AppClientScopeFixture.buildAppClientScope(1L);
+    appRefreshToken = AppRefreshTokenFixture.buildAppRefreshToken(1L);
+
+    var mockedOauth2Util = Mockito.mockStatic(Oauth2Util.class);
+    Mockito.when(
+            Oauth2Util.buildClientCredentialsToken(
+                Mockito.eq(appClient),
+                Mockito.eq(appClientScope),
+                Mockito.eq(Oauth2Fixture.SECRET_KEY),
+                Mockito.eq(Oauth2.TokenType.ACCESS_TOKEN)))
+        .thenReturn(AppAccessTokenFixture.TOKEN);
+
+    Mockito.when(
+            Oauth2Util.buildClientCredentialsToken(
+                Mockito.eq(appClient),
+                Mockito.eq(appClientScope),
+                Mockito.eq(Oauth2Fixture.SECRET_KEY),
+                Mockito.eq(Oauth2.TokenType.REFRESH_TOKEN)))
+        .thenReturn(AppRefreshTokenFixture.TOKEN);
+
+    Mockito.when(
+            this.appClientRepository.findByClientIdAndEntityStatus(
+                Mockito.eq(appClient.getClientId()), Mockito.eq(Status.ACTIVE)))
+        .thenReturn(Optional.of(appClient));
+    Mockito.when(
+            this.appClientScopeRepository.findByAppClientIdAndEntityStatus(
+                Mockito.eq(1L), Mockito.eq(Status.ACTIVE)))
+        .thenReturn(Optional.of(appClientScope));
+
+    Mockito.when(this.appRefreshTokenRepository.save(Mockito.any())).thenReturn(appRefreshToken);
+  }
+
+  @Test
+  public void whenClientCredentialsLogin_ShouldReturnLoginResponse()
+      throws JOSEException, UnsupportedEncodingException {
+
+    var loginResponse = this.oauth2Service.loginClient("TEST01", "TEST-CLIENT-SECRET");
+    Assertions.assertEquals(loginResponse.getClientName(), appClient.getClientName());
+    Assertions.assertEquals(loginResponse.getScopes(), appClientScope.getScopes());
+    Assertions.assertEquals(loginResponse.getAccessToken(), AppAccessTokenFixture.TOKEN);
+    Assertions.assertEquals(loginResponse.getRefreshToken(), AppRefreshTokenFixture.TOKEN);
+    Assertions.assertEquals(loginResponse.getExpiresIn(), appClient.getAccessTokenExpirationTime());
+
+    Mockito.verify(appClientRepository, Mockito.times(2))
+        .findByClientIdAndEntityStatus(
+            Mockito.eq(appClient.getClientId()), Mockito.eq(Status.ACTIVE));
+    Mockito.verify(appClientScopeRepository, Mockito.times(1))
+        .findByAppClientIdAndEntityStatus(Mockito.eq(1L), Mockito.eq(Status.ACTIVE));
+    Mockito.verify(appRefreshTokenRepository, Mockito.times(1)).save(Mockito.any());
+  }
+
+  @Test
+  public void whenWrongClientCredentialsLogin_ShouldReturnWrongCredentialsException()
+      throws UnsupportedEncodingException, JOSEException {
+    Exception exception =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () -> {
+              var loginResponse = this.oauth2Service.loginClient("TEST02", "TEST-CLIENT-SECRET");
+            });
+    var expectedWrongCredentialExceptionMessage = "Wrong Credentials";
+
+    Assertions.assertEquals(exception.getMessage(), expectedWrongCredentialExceptionMessage);
+  }
+}

--- a/src/test/java/com/ea/restaurant/utils/Oauth2UtilTest.java
+++ b/src/test/java/com/ea/restaurant/utils/Oauth2UtilTest.java
@@ -1,0 +1,53 @@
+package com.ea.restaurant.utils;
+
+import com.ea.restaurant.constants.Oauth2;
+import com.ea.restaurant.entities.AppClient;
+import com.ea.restaurant.entities.AppClientScope;
+import com.ea.restaurant.utils.fixtures.AppClientFixture;
+import com.ea.restaurant.utils.fixtures.AppClientScopeFixture;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.proc.BadJOSEException;
+import java.text.ParseException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class Oauth2UtilTest {
+
+  private String secretKey;
+  private AppClient appClient;
+  private AppClientScope appClientScope;
+
+  @BeforeEach
+  public void setUp() {
+    secretKey = "thisIsTheSecretKeyForTest-Etl001";
+    appClient = AppClientFixture.buildAppClient(1L);
+    appClientScope = AppClientScopeFixture.buildAppClientScope(1L);
+  }
+
+  @Test
+  public void whenTokenTypeAccessToken_ShouldCreateAccessToken()
+      throws JOSEException, BadJOSEException, ParseException {
+
+    var accessToken =
+        Oauth2Util.buildClientCredentialsToken(
+            this.appClient, this.appClientScope, secretKey, Oauth2.TokenType.ACCESS_TOKEN);
+    var accessTokenDecoded = Oauth2Util.getTokenDecoded(accessToken, secretKey);
+    Assertions.assertEquals(accessTokenDecoded.getClaim("clientName"), appClient.getClientName());
+    Assertions.assertEquals(accessTokenDecoded.getClaim("scopes"), appClientScope.getScopes());
+    Assertions.assertNotNull(accessToken);
+  }
+
+  @Test
+  public void whenTokenTypeRefreshToken_ShouldCreateRefreshToken()
+      throws JOSEException, BadJOSEException, ParseException {
+
+    var refreshToken =
+        Oauth2Util.buildClientCredentialsToken(
+            this.appClient, this.appClientScope, secretKey, Oauth2.TokenType.REFRESH_TOKEN);
+    var accessTokenDecoded = Oauth2Util.getTokenDecoded(refreshToken, secretKey);
+    Assertions.assertEquals(accessTokenDecoded.getClaim("clientName"), appClient.getClientName());
+    Assertions.assertEquals(accessTokenDecoded.getClaim("scopes"), appClientScope.getScopes());
+    Assertions.assertNotNull(refreshToken);
+  }
+}

--- a/src/test/java/com/ea/restaurant/utils/fixtures/AppAccessTokenFixture.java
+++ b/src/test/java/com/ea/restaurant/utils/fixtures/AppAccessTokenFixture.java
@@ -1,0 +1,29 @@
+package com.ea.restaurant.utils.fixtures;
+
+import com.ea.restaurant.entities.AppAccessToken;
+import java.util.Optional;
+
+public class AppAccessTokenFixture {
+  public static final String TOKEN = "ACCESS-TOKEN-FOR-TEST";
+  public static final Long TESTING_REFRESH_TOKEN_ID = 1L;
+
+  public static AppAccessToken buildAppAccessToken(AppAccessToken appAccessToken) {
+    appAccessToken.setId(appAccessToken.getId());
+    appAccessToken.setToken(Optional.ofNullable(appAccessToken.getToken()).orElse(TOKEN));
+    appAccessToken.setRefreshTokenId(
+        Optional.ofNullable(appAccessToken.getRefreshTokenId()).orElse(TESTING_REFRESH_TOKEN_ID));
+    return appAccessToken;
+  }
+
+  public static AppAccessToken buildAppAccessToken(Long id, String token, Long appRefreshTokenId) {
+    var appAccessTokenExample = new AppAccessToken(id);
+    appAccessTokenExample.setToken(token);
+    appAccessTokenExample.setRefreshTokenId(appRefreshTokenId);
+    return buildAppAccessToken(appAccessTokenExample);
+  }
+
+  public static AppAccessToken buildAppAccessToken(Long id) {
+    var appAccessTokenExample = new AppAccessToken(id);
+    return buildAppAccessToken(appAccessTokenExample);
+  }
+}

--- a/src/test/java/com/ea/restaurant/utils/fixtures/AppClientFixture.java
+++ b/src/test/java/com/ea/restaurant/utils/fixtures/AppClientFixture.java
@@ -1,0 +1,64 @@
+package com.ea.restaurant.utils.fixtures;
+
+import com.ea.restaurant.constants.Status;
+import com.ea.restaurant.entities.AppClient;
+import java.time.Instant;
+import java.util.Optional;
+
+public class AppClientFixture {
+
+  public static final String TESTING_CLIENT_NAME = "TEST";
+  public static final String TESTING_CLIENT_ID = "TEST01";
+  public static final String TESTING_CLIENT_SECRET =
+      "$2b$12$Z3rYJmr5ZuWBJ7h0IdnZ8OmxX3CyVQ3NuVsTkKI4cKx9hZmeyC7yW"; // TEST-CLIENT-SECRET
+  public static final Integer ACCESS_TOKEN_EXPIRATION_TIME = 10;
+  public static final Integer REFRESH_TOKEN_EXPIRATION_TIME = 10;
+  public static final Long CREATED_BY = 1L;
+  public static final Instant CREATED_DATE = Instant.EPOCH;
+  public static final Long UPDATED_BY = 1L;
+  public static final Instant UPDATED_DATE = Instant.EPOCH;
+  public static final Status ENTITY_STATUS = Status.ACTIVE;
+
+  public static AppClient buildAppClient(AppClient appClient) {
+    appClient.setId(appClient.getId());
+    appClient.setClientName(
+        Optional.ofNullable(appClient.getClientName()).orElse(TESTING_CLIENT_NAME));
+    appClient.setClientId(Optional.ofNullable(appClient.getClientId()).orElse(TESTING_CLIENT_ID));
+    appClient.setClientSecret(
+        Optional.ofNullable(appClient.getClientSecret()).orElse(TESTING_CLIENT_SECRET));
+    appClient.setAccessTokenExpirationTime(
+        Optional.ofNullable(appClient.getAccessTokenExpirationTime())
+            .orElse(ACCESS_TOKEN_EXPIRATION_TIME));
+    appClient.setRefreshTokenExpirationTime(
+        Optional.ofNullable(appClient.getRefreshTokenExpirationTime())
+            .orElse(REFRESH_TOKEN_EXPIRATION_TIME));
+    appClient.setEntityStatus(
+        Optional.ofNullable(appClient.getEntityStatus()).orElse(ENTITY_STATUS));
+    appClient.setCreatedDate(Optional.ofNullable(appClient.getCreatedDate()).orElse(CREATED_DATE));
+    appClient.setCreatedBy(Optional.ofNullable(appClient.getCreatedBy()).orElse(CREATED_BY));
+    appClient.setUpdatedBy(Optional.ofNullable(appClient.getUpdatedBy()).orElse(UPDATED_BY));
+    appClient.setUpdatedDate(Optional.ofNullable(appClient.getUpdatedDate()).orElse(UPDATED_DATE));
+    return appClient;
+  }
+
+  public static AppClient buildAppClient(
+      Long id,
+      String clientName,
+      String clientId,
+      String clientSecret,
+      Integer accessTokenExpTime,
+      Integer refreshTokenExpTime) {
+    var appClientExample = new AppClient(id);
+    appClientExample.setClientName(clientName);
+    appClientExample.setClientId(clientId);
+    appClientExample.setClientSecret(clientSecret);
+    appClientExample.setAccessTokenExpirationTime(accessTokenExpTime);
+    appClientExample.setRefreshTokenExpirationTime(refreshTokenExpTime);
+    return buildAppClient(appClientExample);
+  }
+
+  public static AppClient buildAppClient(Long id) {
+    var appClientExample = new AppClient(id);
+    return buildAppClient(appClientExample);
+  }
+}

--- a/src/test/java/com/ea/restaurant/utils/fixtures/AppClientScopeFixture.java
+++ b/src/test/java/com/ea/restaurant/utils/fixtures/AppClientScopeFixture.java
@@ -1,0 +1,48 @@
+package com.ea.restaurant.utils.fixtures;
+
+import com.ea.restaurant.constants.Status;
+import com.ea.restaurant.entities.AppClientScope;
+import java.time.Instant;
+import java.util.Optional;
+
+public class AppClientScopeFixture {
+
+  public static final Long TESTING_APP_CLIENT_ID = 1L;
+  public static final String TESTING_SCOPES = "READ,WRITE";
+  public static final Long CREATED_BY = 1L;
+  public static final Instant CREATED_DATE = Instant.EPOCH;
+  public static final Long UPDATED_BY = 1L;
+  public static final Instant UPDATED_DATE = Instant.EPOCH;
+  public static final Status ENTITY_STATUS = Status.ACTIVE;
+
+  public static AppClientScope buildAppClientScope(AppClientScope appClientScope) {
+    appClientScope.setId(appClientScope.getId());
+    appClientScope.setAppClientId(
+        Optional.ofNullable(appClientScope.getAppClientId()).orElse(TESTING_APP_CLIENT_ID));
+    appClientScope.setScopes(
+        Optional.ofNullable(appClientScope.getScopes()).orElse(TESTING_SCOPES));
+    appClientScope.setEntityStatus(
+        Optional.ofNullable(appClientScope.getEntityStatus()).orElse(ENTITY_STATUS));
+    appClientScope.setCreatedDate(
+        Optional.ofNullable(appClientScope.getCreatedDate()).orElse(CREATED_DATE));
+    appClientScope.setCreatedBy(
+        Optional.ofNullable(appClientScope.getCreatedBy()).orElse(CREATED_BY));
+    appClientScope.setUpdatedBy(
+        Optional.ofNullable(appClientScope.getUpdatedBy()).orElse(UPDATED_BY));
+    appClientScope.setUpdatedDate(
+        Optional.ofNullable(appClientScope.getUpdatedDate()).orElse(UPDATED_DATE));
+    return appClientScope;
+  }
+
+  public static AppClientScope buildAppClientScope(Long id, Long appClientId, String scopes) {
+    var appClientScopeExample = new AppClientScope(id);
+    appClientScopeExample.setAppClientId(appClientId);
+    appClientScopeExample.setScopes(scopes);
+    return buildAppClientScope(appClientScopeExample);
+  }
+
+  public static AppClientScope buildAppClientScope(Long id) {
+    var appClientScopeExample = new AppClientScope(id);
+    return buildAppClientScope(appClientScopeExample);
+  }
+}

--- a/src/test/java/com/ea/restaurant/utils/fixtures/AppRefreshTokenFixture.java
+++ b/src/test/java/com/ea/restaurant/utils/fixtures/AppRefreshTokenFixture.java
@@ -1,0 +1,36 @@
+package com.ea.restaurant.utils.fixtures;
+
+import com.ea.restaurant.constants.Oauth2;
+import com.ea.restaurant.entities.AppRefreshToken;
+import java.util.Optional;
+
+public class AppRefreshTokenFixture {
+
+  public static final String TOKEN = "REFRESH-TOKEN-FOR-TEST";
+  public static final Oauth2.GranType GRANT_TYPE = Oauth2.GranType.CLIENT_CREDENTIALS;
+  public static final Long TESTING_APP_CLIENT_ID = 1L;
+
+  public static AppRefreshToken buildAppRefreshToken(AppRefreshToken appRefreshToken) {
+    appRefreshToken.setId(appRefreshToken.getId());
+    appRefreshToken.setGrantType(
+        Optional.ofNullable(appRefreshToken.getGrantType()).orElse(GRANT_TYPE));
+    appRefreshToken.setToken(Optional.ofNullable(appRefreshToken.getToken()).orElse(TOKEN));
+    appRefreshToken.setAppClientId(
+        Optional.ofNullable(appRefreshToken.getAppClientId()).orElse(TESTING_APP_CLIENT_ID));
+    return appRefreshToken;
+  }
+
+  public static AppRefreshToken buildAppRefreshToken(
+      Long id, String token, Oauth2.GranType granType, Long appClientId) {
+    var appRefreshTokenExample = new AppRefreshToken(id);
+    appRefreshTokenExample.setAppClientId(appClientId);
+    appRefreshTokenExample.setGrantType(granType);
+    appRefreshTokenExample.setToken(token);
+    return buildAppRefreshToken(appRefreshTokenExample);
+  }
+
+  public static AppRefreshToken buildAppRefreshToken(Long id) {
+    var appRefreshTokenExample = new AppRefreshToken(id);
+    return buildAppRefreshToken(appRefreshTokenExample);
+  }
+}

--- a/src/test/java/com/ea/restaurant/utils/fixtures/Oauth2Fixture.java
+++ b/src/test/java/com/ea/restaurant/utils/fixtures/Oauth2Fixture.java
@@ -1,0 +1,5 @@
+package com.ea.restaurant.utils.fixtures;
+
+public class Oauth2Fixture {
+  public static final String SECRET_KEY = "thisIsTheSecretKeyForTest-Etl001";
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This PR  has the implemetation of a `LoginClient` service and all the necessary implementation to create and persist `accessToken`, `refreshToken`, using JWT with `nimbus-jose-jwt` as `spring-boot-starter-security` deprecated JWT.

* Adding `AppClientRepository`
* Adding `AppAccessTokenRepository`
* Adding `AppRefreshTokenRepository`
* Adding `AppClientScopeRepository`
* Adding `Oauth2Service`
* Adding `Oauth2ServiceImpl`
* Adding `Oauth2Utils`