### PR TITLE
Feature: adding e2e test for refresh token grpc

### DIFF
--- a/src/test/java/com/ea/restaurant/grpc/GrpcOauth2ServiceImplE2eTest.java
+++ b/src/test/java/com/ea/restaurant/grpc/GrpcOauth2ServiceImplE2eTest.java
@@ -1,12 +1,18 @@
 package com.ea.restaurant.grpc;
 
+import com.ea.restaurant.constants.Oauth2;
 import com.ea.restaurant.constants.Status;
 import com.ea.restaurant.exceptions.EntityNotFoundException;
+import com.ea.restaurant.repository.AppAccessTokenRepository;
 import com.ea.restaurant.repository.AppClientRepository;
 import com.ea.restaurant.repository.AppClientScopeRepository;
+import com.ea.restaurant.repository.AppRefreshTokenRepository;
 import com.ea.restaurant.service.Oauth2Service;
+import com.ea.restaurant.test.fixture.AppAccessTokenFixture;
+import com.ea.restaurant.test.fixture.AppRefreshTokenFixture;
 import com.ea.restaurant.test.fixture.Oauth2Fixture;
 import com.ea.restaurant.test.util.AuthenticationCallCredentials;
+import com.nimbusds.jose.JOSEException;
 import net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration;
 import net.devh.boot.grpc.client.inject.GrpcClient;
 import net.devh.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration;
@@ -31,6 +37,8 @@ public class GrpcOauth2ServiceImplE2eTest {
   @Autowired private Oauth2Service oauth2Service;
   @Autowired private AppClientRepository appClientRepository;
   @Autowired private AppClientScopeRepository appClientScopeRepository;
+  @Autowired private AppAccessTokenRepository appAccessTokenRepository;
+  @Autowired private AppRefreshTokenRepository appRefreshTokenRepository;
 
   @GrpcClient("inProcess")
   private Oauth2ServiceGrpc.Oauth2ServiceBlockingStub oauth2ServiceBlockingStub;
@@ -64,5 +72,61 @@ public class GrpcOauth2ServiceImplE2eTest {
     Assertions.assertEquals(grpcLoginResponse.getScopes(), scopes.getScopes());
     Assertions.assertEquals(
         grpcLoginResponse.getExpiresIn(), client.getAccessTokenExpirationTime());
+  }
+
+  @Test
+  public void whenRefreshExpiredAccessToken_shouldReturnNewAccessToken() throws JOSEException {
+    var refreshToken = Oauth2Fixture.buildRefreshToken();
+    var appRefreshToken =
+        AppRefreshTokenFixture.buildAppRefreshToken(
+            1L, refreshToken, Oauth2.GranType.CLIENT_CREDENTIALS, 1L);
+    var appRefreshTokenSaved = appRefreshTokenRepository.save(appRefreshToken);
+
+    var expiredAccessToken = Oauth2Fixture.buildExpiredAccessToken();
+    var appAccessToken =
+        AppAccessTokenFixture.buildAppAccessToken(
+            1L, expiredAccessToken, appRefreshTokenSaved.getId());
+
+    appAccessTokenRepository.save(appAccessToken);
+
+    var refreshTokenRequest =
+        RefreshTokenRequest.newBuilder()
+            .setRefreshToken(refreshToken)
+            .setAccessToken(expiredAccessToken)
+            .setClientId("postman001")
+            .setClientSecret("postmansecret01")
+            .build();
+
+    var grpcRefreshTokenResponse = oauth2ServiceBlockingStub.refreshToken(refreshTokenRequest);
+    Assertions.assertNotEquals(expiredAccessToken, grpcRefreshTokenResponse.getAccessToken());
+    Assertions.assertEquals(refreshToken, grpcRefreshTokenResponse.getRefreshToken());
+  }
+
+  @Test
+  public void whenRefreshUnExpiredAccessToken_shouldReturnNewAccessToken() throws JOSEException {
+    var refreshToken = Oauth2Fixture.buildRefreshToken();
+    var appRefreshToken =
+        AppRefreshTokenFixture.buildAppRefreshToken(
+            1L, refreshToken, Oauth2.GranType.CLIENT_CREDENTIALS, 1L);
+    var appRefreshTokenSaved = appRefreshTokenRepository.save(appRefreshToken);
+
+    var unExpiredAccessToken = Oauth2Fixture.buildAccessToken();
+    var appAccessToken =
+        AppAccessTokenFixture.buildAppAccessToken(
+            1L, unExpiredAccessToken, appRefreshTokenSaved.getId());
+
+    appAccessTokenRepository.save(appAccessToken);
+
+    var refreshTokenRequest =
+        RefreshTokenRequest.newBuilder()
+            .setRefreshToken(refreshToken)
+            .setAccessToken(unExpiredAccessToken)
+            .setClientId("postman001")
+            .setClientSecret("postmansecret01")
+            .build();
+
+    var grpcRefreshTokenResponse = oauth2ServiceBlockingStub.refreshToken(refreshTokenRequest);
+    Assertions.assertEquals(unExpiredAccessToken, grpcRefreshTokenResponse.getAccessToken());
+    Assertions.assertEquals(refreshToken, grpcRefreshTokenResponse.getRefreshToken());
   }
 }

--- a/src/test/java/com/ea/restaurant/test/fixture/Oauth2Fixture.java
+++ b/src/test/java/com/ea/restaurant/test/fixture/Oauth2Fixture.java
@@ -16,6 +16,15 @@ public class Oauth2Fixture {
   public static final String TEST_SCOPES = "READ,WRITE";
   public static final int TEST_EXPIRATION_TIME = 10;
 
+  public static String buildAccessToken() throws JOSEException {
+    var appClient = AppClientFixture.buildAppClient(1L);
+    appClient.setAccessTokenExpirationTime(10);
+    var appClientScope = AppClientScopeFixture.buildAppClientScope(1L);
+
+    return Oauth2Util.buildClientCredentialsToken(
+        appClient, appClientScope, Oauth2Fixture.SECRET_KEY, Oauth2.TokenType.ACCESS_TOKEN);
+  }
+
   public static String buildExpiredAccessToken() throws JOSEException {
     var appClient = AppClientFixture.buildAppClient(1L);
     appClient.setAccessTokenExpirationTime(-100000);

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -7,4 +7,4 @@ grpc.server.inProcessName=test
 grpc.server.port=-1
 grpc.client.inProcess.address=in-process:test
 
-oauth2.secret.key=thisIsTheSecretKeyForJava-Etlgrp
+oauth2.secret.key=thisIsTheSecretKeyForTest-Etl001


### PR DESCRIPTION
* Adding e2e test for grpc RefreshToken
 * case 1: testing with expired accessToken
 * case 2: testing with unexpired accessToken