### PR TITLE
refactoring order status history mapper

### DIFF
--- a/src/main/java/com/ea/restaurant/entities/OrderStatusHistory.java
+++ b/src/main/java/com/ea/restaurant/entities/OrderStatusHistory.java
@@ -30,7 +30,7 @@ public class OrderStatusHistory extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private OrderStatus toStatus;
 
-  private String mongodbOrderStatusHistoryUuid;
+  private String mongoOrderStatusHistoryUuid;
 
   @Enumerated(EnumType.STRING)
   private EtlStatus etlStatus;

--- a/src/main/java/com/ea/restaurant/etl/impl/MongoToPostgresqlOrderStatusHistoryEtlService.java
+++ b/src/main/java/com/ea/restaurant/etl/impl/MongoToPostgresqlOrderStatusHistoryEtlService.java
@@ -45,7 +45,7 @@ public class MongoToPostgresqlOrderStatusHistoryEtlService
     var mongoUuids = new HashSet<ObjectId>();
     var orderIds = new ArrayList<Long>();
     for (OrderStatusHistory orderStatusHistory : transformedData) {
-      mongoUuids.add(new ObjectId(orderStatusHistory.getMongodbOrderStatusHistoryUuid()));
+      mongoUuids.add(new ObjectId(orderStatusHistory.getMongoOrderStatusHistoryUuid()));
 
       if (!orderIds.contains(orderStatusHistory.getOrderId())) {
         orderIds.add(orderStatusHistory.getOrderId());

--- a/src/main/java/com/ea/restaurant/util/OrderStatusHistoryMapper.java
+++ b/src/main/java/com/ea/restaurant/util/OrderStatusHistoryMapper.java
@@ -7,7 +7,7 @@ public class OrderStatusHistoryMapper {
   public static OrderStatusHistory mapMongoOrderStatusToPostgresqlOrderStatus(
       MongoOrderStatusHistory mongoOrderStatusHistory) {
     var orderStatusHistory = new OrderStatusHistory();
-    orderStatusHistory.setMongodbOrderStatusHistoryUuid(mongoOrderStatusHistory.getId().toString());
+    orderStatusHistory.setMongoOrderStatusHistoryUuid(mongoOrderStatusHistory.getId().toString());
     orderStatusHistory.setOrderId(mongoOrderStatusHistory.getOrderId());
     orderStatusHistory.setEtlStatus(mongoOrderStatusHistory.getEtlStatus());
     orderStatusHistory.setFromStatus(mongoOrderStatusHistory.getFromStatus());

--- a/src/test/java/com/ea/restaurant/etl/impl/MongoToPostgresqlOrderStatusHistoryEtlServiceIntegrationTest.java
+++ b/src/test/java/com/ea/restaurant/etl/impl/MongoToPostgresqlOrderStatusHistoryEtlServiceIntegrationTest.java
@@ -85,18 +85,18 @@ public class MongoToPostgresqlOrderStatusHistoryEtlServiceIntegrationTest {
   @Test
   public void whenLoad_shouldLoadTransformedOrderStatusIntoDb() {
     var orderStatusHistory1 = OrderStatusHistoryFixture.buildOrderStatusHistory();
-    orderStatusHistory1.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
+    orderStatusHistory1.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
     orderStatusHistory1.setFromStatus(OrderStatus.CANCELLED);
     var orderStatusHistory2 = OrderStatusHistoryFixture.buildOrderStatusHistory();
     orderStatusHistory2.setOrderId(2L);
-    orderStatusHistory2.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
+    orderStatusHistory2.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
     orderStatusHistory2.setFromStatus(OrderStatus.CANCELLED);
 
     var orderStatusHistory3 = OrderStatusHistoryFixture.buildOrderStatusHistory();
-    orderStatusHistory3.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
+    orderStatusHistory3.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
     var orderStatusHistory4 = OrderStatusHistoryFixture.buildOrderStatusHistory();
     orderStatusHistory4.setOrderId(2L);
-    orderStatusHistory4.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
+    orderStatusHistory4.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
 
     var orderIds = List.of(orderStatusHistory1.getOrderId(), orderStatusHistory2.getOrderId());
     var transformedOrderStatusHistories = List.of(orderStatusHistory1, orderStatusHistory2);

--- a/src/test/java/com/ea/restaurant/etl/impl/MongoToPostgresqlOrderStatusHistoryEtlServiceTest.java
+++ b/src/test/java/com/ea/restaurant/etl/impl/MongoToPostgresqlOrderStatusHistoryEtlServiceTest.java
@@ -77,24 +77,24 @@ class MongoToPostgresqlOrderStatusHistoryEtlServiceTest {
   @Test
   void whenLoad_shouldInsertNewOrUpdateBatchOrderStatusHistories() {
     var orderStatusHistory1 = OrderStatusHistoryFixture.buildOrderStatusHistory();
-    orderStatusHistory1.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
+    orderStatusHistory1.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
     orderStatusHistory1.setFromStatus(OrderStatus.CANCELLED);
     var orderStatusHistory2 = OrderStatusHistoryFixture.buildOrderStatusHistory();
     orderStatusHistory2.setOrderId(2L);
-    orderStatusHistory2.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
+    orderStatusHistory2.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
     orderStatusHistory2.setFromStatus(OrderStatus.CANCELLED);
 
     var orderStatusHistory3 = OrderStatusHistoryFixture.buildOrderStatusHistory();
-    orderStatusHistory3.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
+    orderStatusHistory3.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
     var orderStatusHistory4 = OrderStatusHistoryFixture.buildOrderStatusHistory();
     orderStatusHistory4.setOrderId(2L);
-    orderStatusHistory4.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
+    orderStatusHistory4.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
 
     var orderStatusHistory5 = OrderStatusHistoryFixture.buildOrderStatusHistory();
-    orderStatusHistory5.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
+    orderStatusHistory5.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
     orderStatusHistory5.setToStatus(OrderStatus.CANCELLED);
     var orderStatusHistory6 = OrderStatusHistoryFixture.buildOrderStatusHistory();
-    orderStatusHistory6.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
+    orderStatusHistory6.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
     orderStatusHistory6.setOrderId(2L);
     orderStatusHistory6.setToStatus(OrderStatus.CANCELLED);
 

--- a/src/test/java/com/ea/restaurant/test/fixture/OrderStatusHistoryFixture.java
+++ b/src/test/java/com/ea/restaurant/test/fixture/OrderStatusHistoryFixture.java
@@ -35,8 +35,8 @@ public class OrderStatusHistoryFixture {
         Optional.ofNullable(orderStatusHistoryExample.getFromStatus()).orElse(FROM_STATUS));
     orderStatusHistory.setToStatus(
         Optional.ofNullable(orderStatusHistoryExample.getToStatus()).orElse(TO_STATUS));
-    orderStatusHistory.setMongodbOrderStatusHistoryUuid(
-        Optional.ofNullable(orderStatusHistoryExample.getMongodbOrderStatusHistoryUuid())
+    orderStatusHistory.setMongoOrderStatusHistoryUuid(
+        Optional.ofNullable(orderStatusHistoryExample.getMongoOrderStatusHistoryUuid())
             .orElse(MONGODB_ORDER_STATUS_HISTORY_UUID));
     orderStatusHistory.setEtlStatus(
         Optional.ofNullable(orderStatusHistoryExample.getEtlStatus()).orElse(ETL_STATUS));

--- a/src/test/java/com/ea/restaurant/util/OrderStatusHistoryMapperTest.java
+++ b/src/test/java/com/ea/restaurant/util/OrderStatusHistoryMapperTest.java
@@ -1,9 +1,16 @@
 package com.ea.restaurant.util;
 
+import com.ea.restaurant.constants.EtlStatus;
+import com.ea.restaurant.constants.Status;
+import com.ea.restaurant.document.MongoOrderStatusHistory;
 import com.ea.restaurant.test.fixture.MongoOrderStatusHistoryFixture;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.ea.restaurant.util.OrderStatusHistoryMapper.mapMongoOrderStatusToPostgresqlOrderStatus;
 
 class OrderStatusHistoryMapperTest {
 
@@ -19,7 +26,7 @@ class OrderStatusHistoryMapperTest {
 
     Assertions.assertEquals(
         mongoOrderStatusHistory.getId().toString(),
-        orderStatusHistory.getMongodbOrderStatusHistoryUuid());
+        orderStatusHistory.getMongoOrderStatusHistoryUuid());
 
     Assertions.assertEquals(mongoOrderStatusHistory.getOrderId(), orderStatusHistory.getOrderId());
   }

--- a/src/test/java/com/ea/restaurant/util/OrderStatusHistoryUtilTest.java
+++ b/src/test/java/com/ea/restaurant/util/OrderStatusHistoryUtilTest.java
@@ -12,18 +12,18 @@ class OrderStatusHistoryUtilTest {
   @Test
   void whenUpdateLastOrderStatusHistory_shouldUpdateToStatusInLastOrderStatusHistory() {
     var orderStatusHistory1 = OrderStatusHistoryFixture.buildOrderStatusHistory();
-    orderStatusHistory1.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
+    orderStatusHistory1.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
     orderStatusHistory1.setFromStatus(OrderStatus.CANCELLED);
     var orderStatusHistory2 = OrderStatusHistoryFixture.buildOrderStatusHistory();
     orderStatusHistory2.setOrderId(2L);
-    orderStatusHistory2.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
+    orderStatusHistory2.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
     orderStatusHistory2.setFromStatus(OrderStatus.CANCELLED);
 
     var orderStatusHistory3 = OrderStatusHistoryFixture.buildOrderStatusHistory();
-    orderStatusHistory3.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
+    orderStatusHistory3.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cb");
     var orderStatusHistory4 = OrderStatusHistoryFixture.buildOrderStatusHistory();
     orderStatusHistory4.setOrderId(2L);
-    orderStatusHistory4.setMongodbOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
+    orderStatusHistory4.setMongoOrderStatusHistoryUuid("63656f20f2a8a6a247ae31cc");
 
     var transformedOrderStatusHistories = List.of(orderStatusHistory1, orderStatusHistory2);
     var lastOrderStatusHistories = List.of(orderStatusHistory1, orderStatusHistory2);


### PR DESCRIPTION
* Refactoring variable name from `mongoDbordeStatusHistoryUuid` to `mongoORderStatusHistoryUuid` to follow same
name convention as python project.
