### PR TITLE
Refactor: refactoring grpc mongo order status history mapper

### DIFF
--- a/src/main/java/com/ea/restaurant/util/GrpcMongoOrderStatusHistoryMapper.java
+++ b/src/main/java/com/ea/restaurant/util/GrpcMongoOrderStatusHistoryMapper.java
@@ -6,6 +6,7 @@ import com.ea.restaurant.constants.Status;
 import com.ea.restaurant.document.MongoOrderStatusHistory;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 public class GrpcMongoOrderStatusHistoryMapper {
 
@@ -14,9 +15,19 @@ public class GrpcMongoOrderStatusHistoryMapper {
     return MongoOrderStatusHistory.builder()
         .orderId(mongoOrderStatusHistory.getOrderId())
         .fromStatus(OrderStatus.valueOf(mongoOrderStatusHistory.getFromStatus()))
-        .toStatus(OrderStatus.valueOf(mongoOrderStatusHistory.getToStatus()))
+        .toStatus(
+            Optional.ofNullable(mongoOrderStatusHistory)
+                .filter(com.ea.restaurant.grpc.MongoOrderStatusHistory::hasToStatus)
+                .map(mongoOrder -> mongoOrder.getToStatus().getValue())
+                .map(OrderStatus::valueOf)
+                .orElse(null))
         .fromTime(Instant.ofEpochMilli(mongoOrderStatusHistory.getFromTime()))
-        .toTime(Instant.ofEpochMilli(mongoOrderStatusHistory.getToTime()))
+        .toTime(
+            Optional.ofNullable(mongoOrderStatusHistory)
+                .filter(com.ea.restaurant.grpc.MongoOrderStatusHistory::hasToStatus)
+                .map(mongoOrder -> mongoOrder.getToTime().getValue())
+                .map(Instant::ofEpochMilli)
+                .orElse(null))
         .etlStatus(EtlStatus.valueOf(mongoOrderStatusHistory.getEtlStatus()))
         .entityStatus(Status.valueOf(mongoOrderStatusHistory.getEntityStatus()))
         .createdBy(mongoOrderStatusHistory.getCreatedBy())

--- a/src/main/proto/mongoOrderStatusHistory.proto
+++ b/src/main/proto/mongoOrderStatusHistory.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "com.ea.restaurant.grpc";
-
+import "google/protobuf/wrappers.proto";
 
 message InsertMongoOrderStatusHistoriesResponse{
   repeated string uuids = 1;
@@ -11,9 +11,9 @@ message MongoOrderStatusHistory{
   string id = 1;
   int64 orderId = 2;
   int64 fromTime = 3;
-  int64 toTime = 4;
+  google.protobuf.Int64Value toTime = 4;
   string fromStatus = 5;
-  string toStatus = 6;
+  google.protobuf.StringValue toStatus = 6;
   string etlStatus = 7;
   string entityStatus = 8;
   int64 createdBy = 9;

--- a/src/test/java/com/ea/restaurant/grpc/GrpcMongoOrderStatusHistoryServiceImplE2eTest.java
+++ b/src/test/java/com/ea/restaurant/grpc/GrpcMongoOrderStatusHistoryServiceImplE2eTest.java
@@ -6,6 +6,8 @@ import com.ea.restaurant.constants.Status;
 import com.ea.restaurant.document.MongoOrderStatusHistory;
 import com.ea.restaurant.repository.MongoOrderStatusHistoryRepository;
 import com.ea.restaurant.service.MongoOrderStatusHistoryService;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.StringValue;
 import java.util.List;
 import net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration;
 import net.devh.boot.grpc.client.inject.GrpcClient;
@@ -46,9 +48,9 @@ public class GrpcMongoOrderStatusHistoryServiceImplE2eTest {
         com.ea.restaurant.grpc.MongoOrderStatusHistory.newBuilder()
             .setOrderId(1)
             .setFromStatus(OrderStatus.NEW_ORDER.toString())
-            .setToStatus(OrderStatus.IN_PROCESS.toString())
+            .setToStatus(StringValue.of(OrderStatus.IN_PROCESS.toString()))
             .setFromTime(100)
-            .setToTime(100)
+            .setToTime(Int64Value.of(100))
             .setEtlStatus(EtlStatus.UNPROCESSED.toString())
             .setEntityStatus(Status.ACTIVE.toString())
             .setCreatedBy(1L)

--- a/src/test/java/com/ea/restaurant/test/fixture/GrpcMongoOrderStatusHistoryFixture.java
+++ b/src/test/java/com/ea/restaurant/test/fixture/GrpcMongoOrderStatusHistoryFixture.java
@@ -1,0 +1,57 @@
+package com.ea.restaurant.test.fixture;
+
+import com.ea.restaurant.constants.EtlStatus;
+import com.ea.restaurant.constants.OrderStatus;
+import com.ea.restaurant.constants.Status;
+import com.ea.restaurant.grpc.MongoOrderStatusHistory;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.StringValue;
+import java.time.Instant;
+
+public class GrpcMongoOrderStatusHistoryFixture {
+  public static final Long ORDER_ID = 1L;
+  public static final Instant FROM_TIME = Instant.EPOCH;
+  public static final Instant TO_TIME = Instant.EPOCH;
+  public static final OrderStatus FROM_STATUS = OrderStatus.NEW_ORDER;
+  public static final OrderStatus TO_STATUS = OrderStatus.IN_PROCESS;
+  public static final EtlStatus ETL_STATUS = EtlStatus.UNPROCESSED;
+  public static final Long CREATED_BY = 1L;
+  public static final Instant CREATED_DATE = Instant.EPOCH;
+  public static final Long UPDATED_BY = 1L;
+  public static final Instant UPDATED_DATE = Instant.EPOCH;
+  public static final Status ENTITY_STATUS = Status.ACTIVE;
+
+  public static MongoOrderStatusHistory buildMongoOrderStatusHistory(String id) {
+
+    return MongoOrderStatusHistory.newBuilder()
+        .setId(id)
+        .setOrderId(ORDER_ID)
+        .setFromStatus(FROM_STATUS.toString())
+        .setToStatus(StringValue.of(TO_STATUS.toString()))
+        .setFromTime(FROM_TIME.getEpochSecond())
+        .setToTime(Int64Value.of(TO_TIME.getEpochSecond()))
+        .setEtlStatus(ETL_STATUS.toString())
+        .setEntityStatus(ENTITY_STATUS.toString())
+        .setCreatedBy((CREATED_BY))
+        .setCreatedDate(CREATED_DATE.getEpochSecond())
+        .setUpdatedBy(UPDATED_BY)
+        .setUpdatedDate(UPDATED_DATE.getEpochSecond())
+        .build();
+  }
+
+  public static MongoOrderStatusHistory buildMongoOrderStatusHistoryWithOutToStatusAndToTime(
+      String id) {
+    return MongoOrderStatusHistory.newBuilder()
+        .setId(id)
+        .setOrderId(ORDER_ID)
+        .setFromStatus(FROM_STATUS.toString())
+        .setFromTime(FROM_TIME.getEpochSecond())
+        .setEtlStatus(ETL_STATUS.toString())
+        .setEntityStatus(ENTITY_STATUS.toString())
+        .setCreatedBy((CREATED_BY))
+        .setCreatedDate(CREATED_DATE.getEpochSecond())
+        .setUpdatedBy(UPDATED_BY)
+        .setUpdatedDate(UPDATED_DATE.getEpochSecond())
+        .build();
+  }
+}

--- a/src/test/java/com/ea/restaurant/util/GrpcMongoOrderStatusHistoryMapperTest.java
+++ b/src/test/java/com/ea/restaurant/util/GrpcMongoOrderStatusHistoryMapperTest.java
@@ -1,0 +1,47 @@
+package com.ea.restaurant.util;
+
+import static com.ea.restaurant.test.fixture.GrpcMongoOrderStatusHistoryFixture.buildMongoOrderStatusHistory;
+import static com.ea.restaurant.test.fixture.GrpcMongoOrderStatusHistoryFixture.buildMongoOrderStatusHistoryWithOutToStatusAndToTime;
+import static com.ea.restaurant.util.GrpcMongoOrderStatusHistoryMapper.mapGrpcMongoOrderStatusToMongoOrderStatusHistory;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class GrpcMongoOrderStatusHistoryMapperTest {
+
+  @Test
+  void whenMapGrpcMongoOrderStatusHistory_shouldReturnMongoOrderStatusHistory() {
+    var grpcMongoOrderStatusHistory = buildMongoOrderStatusHistory("63656f20f2a8a6a247ae31cb");
+
+    var mappedGrpcMongoOrderStatusToMongoOrderStatusHistory =
+        mapGrpcMongoOrderStatusToMongoOrderStatusHistory(grpcMongoOrderStatusHistory);
+
+    Assertions.assertEquals(
+        grpcMongoOrderStatusHistory.getFromStatus(),
+        mappedGrpcMongoOrderStatusToMongoOrderStatusHistory.getFromStatus().toString());
+    Assertions.assertEquals(
+        grpcMongoOrderStatusHistory.getOrderId(),
+        mappedGrpcMongoOrderStatusToMongoOrderStatusHistory.getOrderId());
+    Assertions.assertEquals(
+        grpcMongoOrderStatusHistory.getEtlStatus(),
+        mappedGrpcMongoOrderStatusToMongoOrderStatusHistory.getEtlStatus().toString());
+    Assertions.assertEquals(
+        grpcMongoOrderStatusHistory.getEntityStatus(),
+        mappedGrpcMongoOrderStatusToMongoOrderStatusHistory.getEntityStatus().toString());
+    Assertions.assertEquals(
+        grpcMongoOrderStatusHistory.getCreatedBy(),
+        mappedGrpcMongoOrderStatusToMongoOrderStatusHistory.getCreatedBy());
+  }
+
+  @Test
+  void whenMapGrpcMongoOrderStatusHistoryWithoutToStatusAndToTime_ShouldReturnNull() {
+    var grpcMongoOrderStatusHistory =
+        buildMongoOrderStatusHistoryWithOutToStatusAndToTime("63656f20f2a8a6a247ae31cb");
+
+    var mappedGrpcMongoOrderStatusToMongoOrderStatusHistory =
+        mapGrpcMongoOrderStatusToMongoOrderStatusHistory(grpcMongoOrderStatusHistory);
+
+    Assertions.assertNull(mappedGrpcMongoOrderStatusToMongoOrderStatusHistory.getToStatus());
+    Assertions.assertNull(mappedGrpcMongoOrderStatusToMongoOrderStatusHistory.getToTime());
+  }
+}

--- a/src/test/java/com/ea/restaurant/util/OrderStatusHistoryMapperTest.java
+++ b/src/test/java/com/ea/restaurant/util/OrderStatusHistoryMapperTest.java
@@ -1,16 +1,9 @@
 package com.ea.restaurant.util;
 
-import com.ea.restaurant.constants.EtlStatus;
-import com.ea.restaurant.constants.Status;
-import com.ea.restaurant.document.MongoOrderStatusHistory;
 import com.ea.restaurant.test.fixture.MongoOrderStatusHistoryFixture;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.time.Instant;
-
-import static com.ea.restaurant.util.OrderStatusHistoryMapper.mapMongoOrderStatusToPostgresqlOrderStatus;
 
 class OrderStatusHistoryMapperTest {
 


### PR DESCRIPTION
* Refactoring grpc mongo order status history to return `null` when `toStatua` and `toTime` came empty from python.
* Refactoring grpc mongo order status protofile to wrap toStatus and toTime
* Adding test for grpc mongo order status history mapper
* Adding fixture for grpc mongo order statud history