### PR TITLE
adding id to the grpc mongo order status mapper

### DIFF
--- a/src/main/java/com/ea/restaurant/util/GrpcMongoOrderStatusHistoryMapper.java
+++ b/src/main/java/com/ea/restaurant/util/GrpcMongoOrderStatusHistoryMapper.java
@@ -7,12 +7,14 @@ import com.ea.restaurant.document.MongoOrderStatusHistory;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import org.bson.types.ObjectId;
 
 public class GrpcMongoOrderStatusHistoryMapper {
 
   public static MongoOrderStatusHistory mapGrpcMongoOrderStatusToMongoOrderStatusHistory(
       com.ea.restaurant.grpc.MongoOrderStatusHistory mongoOrderStatusHistory) {
     return MongoOrderStatusHistory.builder()
+        .id(new ObjectId(mongoOrderStatusHistory.getId()))
         .orderId(mongoOrderStatusHistory.getOrderId())
         .fromStatus(OrderStatus.valueOf(mongoOrderStatusHistory.getFromStatus()))
         .toStatus(

--- a/src/test/java/com/ea/restaurant/util/GrpcMongoOrderStatusHistoryMapperTest.java
+++ b/src/test/java/com/ea/restaurant/util/GrpcMongoOrderStatusHistoryMapperTest.java
@@ -4,6 +4,7 @@ import static com.ea.restaurant.test.fixture.GrpcMongoOrderStatusHistoryFixture.
 import static com.ea.restaurant.test.fixture.GrpcMongoOrderStatusHistoryFixture.buildMongoOrderStatusHistoryWithOutToStatusAndToTime;
 import static com.ea.restaurant.util.GrpcMongoOrderStatusHistoryMapper.mapGrpcMongoOrderStatusToMongoOrderStatusHistory;
 
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +32,9 @@ public class GrpcMongoOrderStatusHistoryMapperTest {
     Assertions.assertEquals(
         grpcMongoOrderStatusHistory.getCreatedBy(),
         mappedGrpcMongoOrderStatusToMongoOrderStatusHistory.getCreatedBy());
+    Assertions.assertEquals(
+        new ObjectId(grpcMongoOrderStatusHistory.getId()),
+        mappedGrpcMongoOrderStatusToMongoOrderStatusHistory.getId());
   }
 
   @Test


### PR DESCRIPTION
* Adding id to the grpc mongo order status history mapper to keep same id of mongo order status from python.